### PR TITLE
Fix: force_unicode does not exist in Django for python3

### DIFF
--- a/askbot/conf/settings_wrapper.py
+++ b/askbot/conf/settings_wrapper.py
@@ -25,7 +25,10 @@ import logging
 from django.conf import settings as django_settings
 from django.core.cache import cache
 from django.contrib.sites.models import Site
-from django.utils.encoding import force_unicode
+try:
+    from django.utils.encoding import force_unicode as force_text #py2.7
+except ImportError:
+    from django.utils.encoding import force_text #py3.x
 from django.utils.functional import lazy
 from django.utils.translation import get_language
 from django.utils.translation import string_concat
@@ -144,7 +147,7 @@ class ConfigSettings(object):
             anchor='id_%s__%s__%s' % (group_name, setting_name, get_language())
         )
         if len(data) == 4:
-            return force_unicode(string_concat(link, ' (', data[3], ')'))
+            return force_text(string_concat(link, ' (', data[3], ')'))
         return link
 
     def get_related_settings_info(self, *requirements):

--- a/askbot/deps/livesettings/values.py
+++ b/askbot/deps/livesettings/values.py
@@ -10,7 +10,10 @@ from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.cache import cache
 import simplejson
-from django.utils.encoding import force_unicode
+try:
+        from django.utils.encoding import force_unicode as force_text #py2.7
+except ImportError:
+        from django.utils.encoding import force_text #py3.x
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
@@ -322,16 +325,16 @@ class Value(object):
         return new_value
 
     def _default_text(self):
-        if not self.use_default or force_unicode(self.default) == '':
+        if not self.use_default or force_text(self.default) == '':
             note = ""
         elif self.choices:
             work = []
             for x in self.choices:
                 if x[0] in self.default:
-                    work.append(force_unicode(x[1]))
+                    work.append(force_text(x[1]))
             note = _('Default value: ') + str(", ".join(work))
         else:
-            note = _("Default value: %s") % force_unicode(self.default)
+            note = _("Default value: %s") % force_text(self.default)
 
         return note
 

--- a/askbot/mail/messages.py
+++ b/askbot/mail/messages.py
@@ -10,7 +10,10 @@ from django.conf import settings as django_settings
 from django.core.urlresolvers import reverse
 from django.template import Context
 from django.template.loader import get_template
-from django.utils.encoding import force_unicode
+try:
+        from django.utils.encoding import force_unicode as force_text #py2.7
+except ImportError:
+        from django.utils.encoding import force_text #py3.x
 from django.utils.html import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from askbot import const
@@ -152,7 +155,7 @@ class BaseEmail(object):
         else:
             LOG.warning(
                 'Attempting to send disabled email "%s"',
-                force_unicode(self.title)
+                force_text(self.title)
             )
 
 
@@ -628,7 +631,7 @@ class BatchEmailAlert(BaseEmail):
         qq = Post.objects.filter(post_type='question')[:2]
 
         act_list = list()
-        act_list.append(force_unicode(_('new question')))
+        act_list.append(force_text(_('new question')))
         format_action_count('%(num)d rev', 3, act_list)
         format_action_count('%(num)d ans', 2, act_list)
         qdata.append({
@@ -794,7 +797,7 @@ class ApprovedPostNotificationRespondable(BaseEmail):
 
     def process_context(self, context):
         revision = context['revision']
-        prompt = force_unicode(_('To add to your post EDIT ABOVE THIS LINE'))
+        prompt = force_text(_('To add to your post EDIT ABOVE THIS LINE'))
         context.update({
             'site_name': askbot_settings.APP_SHORT_NAME,
             'post': revision.post,

--- a/askbot/middleware/spaceless.py
+++ b/askbot/middleware/spaceless.py
@@ -5,7 +5,10 @@ http://www.davidcramer.net/code/369/spaceless-html-in-django.html
 """
 import re
 from django.utils.functional import allow_lazy
-from django.utils.encoding import force_unicode
+try:
+        from django.utils.encoding import force_unicode as force_text #py2.7
+except ImportError:
+        from django.utils.encoding import force_text #py3.x
 
 def reduce_spaces_between_tags(value):
     """Returns the given HTML with all spaces between tags removed.
@@ -13,7 +16,7 @@ def reduce_spaces_between_tags(value):
     do not appear glued together
     slight mod of django.utils.html import strip_spaces_between_tags
     """
-    return re.sub(r'>\s+<', '> <', force_unicode(value))
+    return re.sub(r'>\s+<', '> <', force_text(value))
 reduce_spaces_between_tags = allow_lazy(reduce_spaces_between_tags, str)
 
 class SpacelessMiddleware(object):

--- a/askbot/views/avatar_views.py
+++ b/askbot/views/avatar_views.py
@@ -11,7 +11,10 @@ from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.encoding import force_unicode
+try:
+        from django.utils.encoding import force_unicode as force_text#py2.7
+except ImportError:
+        from django.utils.encoding import force_text #py3.x
 from django.utils.translation import ugettext as _
 import functools
 
@@ -178,7 +181,7 @@ def upload(request, user_id=None):
                 message = _('Avatar uploaded and set as primary')
             else:
                 errors = get_error_list(form)
-                message = ', '.join([force_unicode(v) for v in errors])
+                message = ', '.join([force_text(v) for v in errors])
         else:
             message = _('Please choose file to upload')
 


### PR DESCRIPTION
* new name is force_text()
* applied:
  try:
    from django.utils.encoding import force_unicode #py2.7
  except ImportError:
    from django.utils.encoding import force_text as force_unicode #py3.x
