### PR TITLE
Python 3: assertItemsEqual -> assertCountEqual

### DIFF
--- a/askbot/tests/test_post_model.py
+++ b/askbot/tests/test_post_model.py
@@ -476,7 +476,7 @@ class ThreadRenderCacheUpdateTests(AskbotTestCase):
 
         self.assertEqual('test question title', question.thread.title)
         self.assertEqual('test body text', question.text)
-        self.assertItemsEqual(['tag1', 'tag2'], list(question.thread.tags.values_list('name', flat=True)))
+        self.assertCountEqual(['tag1', 'tag2'], list(question.thread.tags.values_list('name', flat=True)))
         self.assertEqual(0, question.thread.answer_count)
 
         self.assertTrue(question.thread.summary_html_cached())  # <<< make sure that caching backend is set up properly (i.e. it's not dummy)
@@ -531,7 +531,7 @@ class ThreadRenderCacheUpdateTests(AskbotTestCase):
         question = Post.objects.all()[0]
         self.assertRedirects(response=response, expected_url=question.get_absolute_url())
 
-        self.assertItemsEqual(['tag1', 'tag2'], list(question.thread.tags.values_list('name', flat=True)))
+        self.assertCountEqual(['tag1', 'tag2'], list(question.thread.tags.values_list('name', flat=True)))
 
         self.assertTrue(question.thread.summary_html_cached())  # <<< make sure that caching backend is set up properly (i.e. it's not dummy)
         html = self._html_for_question(question)

--- a/askbot/tests/test_search_state.py
+++ b/askbot/tests/test_search_state.py
@@ -237,7 +237,7 @@ class SearchStateTests(AskbotTestCase):
         self.assertTrue(ss.query is ss2.query)
 
         self.assertFalse(ss.tags is ss2.tags)
-        self.assertItemsEqual(ss.tags, ss2.tags)
+        self.assertCountEqual(ss.tags, ss2.tags)
 
         self.assertEqual(ss.author, 12)
         self.assertTrue(ss.author is ss2.author)
@@ -248,10 +248,10 @@ class SearchStateTests(AskbotTestCase):
         self.assertEqual(ss.stripped_query, 'hejho')
         self.assertTrue(ss.stripped_query is ss2.stripped_query)
 
-        self.assertItemsEqual(ss.query_tags, ['tag1', 'tag2'])
+        self.assertCountEqual(ss.query_tags, ['tag1', 'tag2'])
         self.assertFalse(ss.query_tags is ss2.query_tags)
 
-        self.assertItemsEqual(ss.query_users, ['user', 'user2'])
+        self.assertCountEqual(ss.query_users, ['user', 'user2'])
         self.assertFalse(ss.query_users is ss2.query_users)
 
         self.assertEqual(ss.query_title, 'what is this?')
@@ -268,8 +268,8 @@ class SearchStateTests(AskbotTestCase):
         ss2 = ss.deepcopy()
 
         self.assertFalse(ss.tags is ss2.tags)
-        self.assertItemsEqual(ss.tags, ss2.tags)
-        self.assertItemsEqual([], ss2.tags)
+        self.assertCountEqual(ss.tags, ss2.tags)
+        self.assertCountEqual([], ss2.tags)
 
     def test_cannot_add_already_added_tag(self):
         ss = SearchState.get_empty().add_tag('double').add_tag('double')


### PR DESCRIPTION
See https://bugs.python.org/issue17866

and especially https://bugs.python.org/msg265888 : Documentation clamined to compare not only the counts, but the actual sorted elements themselves.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>