### PR TITLE
Fix: unhashable type: IntegerValue

### DIFF
--- a/askbot/deps/livesettings/values.py
+++ b/askbot/deps/livesettings/values.py
@@ -520,7 +520,7 @@ class Value(object):
                     except SettingNotSet:
                         pass
 
-                signals.configuration_value_changed.send(self,
+                signals.configuration_value_changed.send(self.__class__,
                         old_value=current_value,
                         new_value=new_value, setting=self,
                         language_code=language_code)


### PR DESCRIPTION
> by convention, the sender is the model class, not the model instance.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>