### PR TITLE
Fix skin upload test

### DIFF
--- a/askbot/conf/settings_wrapper.py
+++ b/askbot/conf/settings_wrapper.py
@@ -25,6 +25,7 @@ import logging
 from django.conf import settings as django_settings
 from django.core.cache import cache
 from django.contrib.sites.models import Site
+from django.core.files import uploadedfile
 from django.utils.encoding import force_text
 from django.utils.functional import lazy
 from django.utils.translation import get_language
@@ -90,7 +91,7 @@ class ConfigSettings(object):
         """returns setting to the default value"""
         self.update(key, self.get_default(key))
 
-    def update(self, key, value, language_code=None):
+    def update(self, key, value: uploadedfile.UploadedFile, language_code=None):
         try:
             setting = config_get(self.__group_map[key], key)
             if setting.localized:

--- a/askbot/tests/test_skins.py
+++ b/askbot/tests/test_skins.py
@@ -60,7 +60,7 @@ class SkinTests(TestCase):
                             'images',
                             'logo.gif'
                         )
-        logo_file = open(logo_src, 'r')
+        logo_file = open(logo_src, 'rb')
         new_logo = UploadedFile(file = logo_file)
         askbot_settings.update('SITE_LOGO_URL', new_logo)
         logo_url = askbot_settings.SITE_LOGO_URL


### PR DESCRIPTION
`open(logo_src, 'r')` tries to utf-8-decode the gif.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>